### PR TITLE
Reverting to regularizing logits in LS/TR term

### DIFF
--- a/example-scripts/cifar-example.sh
+++ b/example-scripts/cifar-example.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+source set_env.sh
 python experiments/cifar10/train.py \
 	--run_type tan-only \
 	--generator gru \

--- a/example-scripts/mnist-example-small.sh
+++ b/example-scripts/mnist-example-small.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+source set_env.sh
 python experiments/mnist/train.py \
 	--run_type tan-only \
 	--generator mean_field \

--- a/example-scripts/mnist-example.sh
+++ b/example-scripts/mnist-example.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+source set_env.sh
 python experiments/mnist/train.py \
 	--run_type tan-only \
 	--generator mean_field \

--- a/experiments/train_scripts.py
+++ b/experiments/train_scripts.py
@@ -98,7 +98,7 @@ flags.DEFINE_integer("n_disc_steps", 1, "Number of steps to take w disc. model")
 # End model params
 flags.DEFINE_string("end_discriminator", "resnet", "End discriminator class")
 flags.DEFINE_integer("end_epochs", 100, "Number of training epochs")
-flags.DEFINE_integer("end_batch_size", 100, "Batch size to use for end model")
+flags.DEFINE_integer("end_batch_size", 50, "Batch size to use for end model")
 flags.DEFINE_boolean("end_per_img_std", True, "Apply per-image standardization")
 flags.DEFINE_integer("n_per_class", 500,
     "Number of data pts. per class for end model")
@@ -125,9 +125,9 @@ flags.DEFINE_string("end_optimizer", "momentum", "End optimizer")
 flags.DEFINE_integer("save_end_model_every", 50,
     "Epoch frequency at which to save end model checkpoints")
 # Whether to use unlabeled data local smoothness reg. term
-flags.DEFINE_float("ls_term", 0.0, "Unlabeled data local smoothness term")
-flags.DEFINE_integer("ls_term_n_passes", 5, "N passes per data point")
-flags.DEFINE_integer("end_batch_size_u", 100,
+flags.DEFINE_float("ls_term", 0.1, "Unlabeled data local smoothness term")
+flags.DEFINE_integer("ls_term_n_passes", 1, "N passes per data point")
+flags.DEFINE_integer("end_batch_size_u", 10,
     "Batch size for unlabeled data for LS reg term")
 
 # Training fold params

--- a/tanda/discriminator/discriminator.py
+++ b/tanda/discriminator/discriminator.py
@@ -115,8 +115,9 @@ class Discriminator(object):
             # Pass through the network
             # NOTE: Any random ops e.g. dropout, etc. should be used here in
             # train mode!
-            # NOTE: We use prediction vectors not logits now
-            pred_u_t_arr = tf.TensorArray(tf.float32, Np)
+            # NOTE: We regularize logits (not prediction vector); this works
+            # much better empirically
+            logits_u_t_arr = tf.TensorArray(tf.float32, Np)
             with tf.variable_scope(name, reuse=True):
                 
                 # Add several transformed versions' logits
@@ -128,11 +129,10 @@ class Discriminator(object):
                                     train=True,
                                     reuse=True
                                 )
-                    pred_u_t = tf.nn.softmax(logits_u_t)
-                    pred_u_t_arr = pred_u_t_arr.write(i, pred_u_t)
+                    logits_u_t_arr = logits_u_t_arr.write(i, logits_u_t)
             
             # Add TR reg term to loss
-            u_reg_loss = self._tr_term(pred_u_t_arr, Np)
+            u_reg_loss = self._tr_term(logits_u_t_arr, Np)
             summaries.append(tf.summary.scalar("U_loss", u_reg_loss))
             self.loss += ls_term * u_reg_loss
 


### PR DESCRIPTION
 Works significantly better, tested on CIFAR-10 to confirm; hardcoded conservative defaults (ls_term=0.1, ls_term_n_passes=1, batch_size_u=10, batch_size=50) based on best-scoring CIFAR-10 model with LS/TR term